### PR TITLE
add fv3_ccpp_gfs_v16_RRTMGP_c192L127 test and ccpp fix to compile gfs…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  url = https://github.com/junwang-noaa/fv3atm
+  branch = rrtmgp_test
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Wed Jan  6 10:18:55 MST 2021
+Thu Jan  7 14:10:30 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,7 +249,7 @@ Test 004 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,7 +317,7 @@ Test 005 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -385,7 +385,7 @@ Test 006 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -453,7 +453,7 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -521,7 +521,7 @@ Test 008 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_control_debug_prod
 Checking test 015 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 015 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1001,7 +1001,7 @@ Test 016 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 017 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1069,7 +1069,7 @@ Test 017 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1137,7 +1137,7 @@ Test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1205,7 +1205,7 @@ Test 019 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1279,7 +1279,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1347,7 +1347,7 @@ Test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23958/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_62180/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1365,5 +1365,5 @@ Test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 10:36:57 MST 2021
-Elapsed time: 00h:18m:02s. Have a nice day!
+Thu Jan  7 14:28:33 MST 2021
+Elapsed time: 00h:18m:04s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Wed Jan  6 10:34:23 MST 2021
+Thu Jan  7 16:45:27 MST 2021
 Start Regression test
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_read_inc_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -449,7 +449,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
- Comparing dynf000.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_ca_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lndp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_lndp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_iau_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_lheatstrg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_multigases_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1025,7 +1025,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_control_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1093,7 +1093,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_stretched_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1149,7 +1149,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_stretched_nest_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1216,7 +1216,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_regional_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1227,7 +1227,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_regional_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1236,7 +1236,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_regional_quilt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1247,7 +1247,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1258,7 +1258,7 @@ Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_control_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1308,7 +1308,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfdlmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1356,7 +1356,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1404,7 +1404,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1452,7 +1452,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_csawmg_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1500,7 +1500,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_satmedmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1548,7 +1548,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_satmedmfq_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1596,7 +1596,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1644,7 +1644,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1696,7 +1696,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_cpt_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1750,7 +1750,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gsd_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rap_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_rap_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_hrrr_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_hrrr_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_thompson_no_aero_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2182,7 +2182,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v15p2_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v15p2_prod
 Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2250,7 +2250,7 @@ Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_prod
 Checking test 043 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2330,7 +2330,7 @@ Test 043 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 044 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 044 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 045 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2448,7 +2448,7 @@ Test 045 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2516,7 +2516,7 @@ Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2584,7 +2584,7 @@ Test 047 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gocart_clm_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gocart_clm_prod
 Checking test 048 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2632,7 +2632,7 @@ Test 048 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 049 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2700,7 +2700,7 @@ Test 049 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 050 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2768,7 +2768,7 @@ Test 050 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2786,7 +2786,7 @@ Test 051 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 052 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2854,7 +2854,7 @@ Test 052 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 053 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2922,7 +2922,7 @@ Test 053 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2990,7 +2990,7 @@ Test 054 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 055 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3058,7 +3058,7 @@ Test 055 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gsd_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gsd_debug_prod
 Checking test 056 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3126,7 +3126,7 @@ Test 056 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 057 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3194,7 +3194,7 @@ Test 057 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_thompson_debug_prod
 Checking test 058 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3262,7 +3262,7 @@ Test 058 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 059 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3330,7 +3330,7 @@ Test 059 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 060 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3398,7 +3398,7 @@ Test 060 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 061 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3466,7 +3466,7 @@ Test 061 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 062 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3484,7 +3484,7 @@ Test 062 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_control_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_control_prod
 Checking test 063 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3537,7 +3537,7 @@ Test 063 cpld_control PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restart_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restart_prod
 Checking test 064 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3590,7 +3590,7 @@ Test 064 cpld_restart PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_controlfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_controlfrac_prod
 Checking test 065 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3643,7 +3643,7 @@ Test 065 cpld_controlfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restartfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restartfrac_prod
 Checking test 066 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3696,7 +3696,7 @@ Test 066 cpld_restartfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_2threads_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_2threads_prod
 Checking test 067 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3749,7 +3749,7 @@ Test 067 cpld_2threads PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_decomp_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_decomp_prod
 Checking test 068 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3802,7 +3802,7 @@ Test 068 cpld_decomp PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_satmedmf_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_satmedmf_prod
 Checking test 069 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3855,7 +3855,7 @@ Test 069 cpld_satmedmf PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_ca_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_ca_prod
 Checking test 070 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3908,7 +3908,7 @@ Test 070 cpld_ca PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_control_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_control_c192_prod
 Checking test 071 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -3961,7 +3961,7 @@ Test 071 cpld_control_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restart_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restart_c192_prod
 Checking test 072 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4014,7 +4014,7 @@ Test 072 cpld_restart_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_controlfrac_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_controlfrac_c192_prod
 Checking test 073 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4067,7 +4067,7 @@ Test 073 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restartfrac_c192_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restartfrac_c192_prod
 Checking test 074 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4120,7 +4120,7 @@ Test 074 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_control_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_control_c384_prod
 Checking test 075 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4176,7 +4176,7 @@ Test 075 cpld_control_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restart_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restart_c384_prod
 Checking test 076 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4232,7 +4232,7 @@ Test 076 cpld_restart_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_controlfrac_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_controlfrac_c384_prod
 Checking test 077 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4288,7 +4288,7 @@ Test 077 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restartfrac_c384_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restartfrac_c384_prod
 Checking test 078 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4344,7 +4344,7 @@ Test 078 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_bmark_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_bmark_prod
 Checking test 079 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4400,7 +4400,7 @@ Test 079 cpld_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restart_bmark_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restart_bmark_prod
 Checking test 080 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4456,7 +4456,7 @@ Test 080 cpld_restart_bmark PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_bmarkfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_bmarkfrac_prod
 Checking test 081 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4512,7 +4512,7 @@ Test 081 cpld_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restart_bmarkfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restart_bmarkfrac_prod
 Checking test 082 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4568,7 +4568,7 @@ Test 082 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_bmarkfrac_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_bmarkfrac_v16_prod
 Checking test 083 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4624,7 +4624,7 @@ Test 083 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_restart_bmarkfrac_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_restart_bmarkfrac_v16_prod
 Checking test 084 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4680,7 +4680,7 @@ Test 084 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_bmark_wave_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_bmark_wave_prod
 Checking test 085 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4739,7 +4739,7 @@ Test 085 cpld_bmark_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_bmarkfrac_wave_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_bmarkfrac_wave_prod
 Checking test 086 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4798,7 +4798,7 @@ Test 086 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_bmarkfrac_wave_v16_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_bmarkfrac_wave_v16_prod
 Checking test 087 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4857,7 +4857,7 @@ Test 087 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_debug_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_debug_prod
 Checking test 088 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -4910,7 +4910,7 @@ Test 088 cpld_debug PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_debugfrac_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/cpld_debugfrac_prod
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/cpld_debugfrac_prod
 Checking test 089 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -4963,7 +4963,7 @@ Test 089 cpld_debugfrac PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_control_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_control_cfsr
 Checking test 090 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4972,7 +4972,7 @@ Test 090 datm_control_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_restart_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_restart_cfsr
 Checking test 091 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4981,7 +4981,7 @@ Test 091 datm_restart_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_control_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_control_gefs
 Checking test 092 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4990,7 +4990,7 @@ Test 092 datm_control_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_bulk_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_bulk_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_bulk_cfsr
 Checking test 093 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -4999,7 +4999,7 @@ Test 093 datm_bulk_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_bulk_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_bulk_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_bulk_gefs
 Checking test 094 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5008,7 +5008,7 @@ Test 094 datm_bulk_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_mx025_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_mx025_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_mx025_cfsr
 Checking test 095 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5020,7 +5020,7 @@ Test 095 datm_mx025_cfsr PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_mx025_gefs
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_mx025_gefs
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_mx025_gefs
 Checking test 096 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5032,7 +5032,7 @@ Test 096 datm_mx025_gefs PASS
 
 
 baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_debug_cfsr
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_48369/datm_debug_cfsr
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_47838/datm_debug_cfsr
 Checking test 097 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5041,5 +5041,5 @@ Test 097 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 11:50:40 MST 2021
-Elapsed time: 01h:16m:17s. Have a nice day!
+Thu Jan  7 18:25:35 MST 2021
+Elapsed time: 01h:40m:08s. Have a nice day!

--- a/tests/RegressionTests_gaea.intel.log
+++ b/tests/RegressionTests_gaea.intel.log
@@ -1,9 +1,9 @@
-Wed Jan  6 16:07:10 EST 2021
+Thu Jan  7 17:04:09 EST 2021
 Start Regression test
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_decomp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_2threads_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_read_inc_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_read_inc_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_stochy_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_ca_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_ca_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lndp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_lndp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_iau_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_iau_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_lheatstrg_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_multigases_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_multigases_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1025,7 +1025,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_control_32bit_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1093,7 +1093,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_stretched_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1149,7 +1149,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_stretched_nest_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1216,7 +1216,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_control_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_regional_control_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1227,7 +1227,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_restart_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_regional_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1236,7 +1236,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_regional_quilt_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1247,18 +1247,18 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc .........OK
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_control_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1308,7 +1308,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfdlmp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1356,7 +1356,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1404,7 +1404,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1452,7 +1452,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_csawmg_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1500,7 +1500,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmf_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_satmedmf_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1548,7 +1548,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_satmedmfq_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1596,7 +1596,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1644,7 +1644,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1696,7 +1696,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_cpt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_cpt_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1750,7 +1750,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gsd_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rap_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_rap_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_hrrr_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_hrrr_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_thompson_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_thompson_no_aero_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2182,7 +2182,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v15p2_prod
 Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2250,7 +2250,7 @@ Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_prod
 Checking test 043 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2330,7 +2330,7 @@ Test 043 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 044 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 044 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 045 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2448,7 +2448,7 @@ Test 045 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2516,7 +2516,7 @@ Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2584,7 +2584,7 @@ Test 047 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 048 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2632,7 +2632,7 @@ Test 048 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 049 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2680,7 +2680,7 @@ Test 049 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gocart_clm_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gocart_clm_prod
 Checking test 050 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2728,7 +2728,7 @@ Test 050 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 051 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2796,7 +2796,7 @@ Test 051 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 052 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2864,7 +2864,7 @@ Test 052 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2882,7 +2882,7 @@ Test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 054 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2950,7 +2950,7 @@ Test 054 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 055 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3018,7 +3018,7 @@ Test 055 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 056 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3086,7 +3086,7 @@ Test 056 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 057 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3154,7 +3154,7 @@ Test 057 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gsd_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gsd_debug_prod
 Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3222,7 +3222,7 @@ Test 058 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3290,7 +3290,7 @@ Test 059 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_thompson_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_thompson_debug_prod
 Checking test 060 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3358,7 +3358,7 @@ Test 060 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3426,7 +3426,7 @@ Test 061 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3494,7 +3494,7 @@ Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3562,7 +3562,7 @@ Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lustre/f2/pdata/esrl/gsd/ufs/ufs-weather-model/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_3647/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lustre/f2/scratch/Dom.Heinzeller/FV3_RT/rt_42823/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3580,5 +3580,5 @@ Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 16:42:58 EST 2021
-Elapsed time: 00h:35m:50s. Have a nice day!
+Thu Jan  7 17:40:03 EST 2021
+Elapsed time: 00h:35m:55s. Have a nice day!

--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,9 +1,9 @@
-Wed Jan  6 16:39:25 UTC 2021
+Thu Jan  7 16:23:58 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -119,7 +119,7 @@ Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -199,7 +199,7 @@ Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 004 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -249,7 +249,7 @@ Test 004 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 005 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -317,7 +317,7 @@ Test 005 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 006 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -385,7 +385,7 @@ Test 006 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 007 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -453,7 +453,7 @@ Test 007 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 008 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -521,7 +521,7 @@ Test 008 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gsd_prod
 Checking test 009 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -613,7 +613,7 @@ Test 009 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_thompson_prod
 Checking test 010 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -681,7 +681,7 @@ Test 010 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_thompson_no_aero_prod
 Checking test 011 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -749,7 +749,7 @@ Test 011 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_rrfs_v1beta_prod
 Checking test 012 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -817,7 +817,7 @@ Test 012 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 013 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -885,7 +885,7 @@ Test 013 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -903,7 +903,7 @@ Test 014 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_control_debug_prod
 Checking test 015 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -933,7 +933,7 @@ Test 015 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 016 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1001,7 +1001,7 @@ Test 016 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 017 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1069,7 +1069,7 @@ Test 017 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1137,7 +1137,7 @@ Test 018 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 019 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1205,7 +1205,7 @@ Test 019 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_multigases_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1279,7 +1279,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1347,7 +1347,7 @@ Test 021 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/GNU/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_150851/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_121119/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -1365,5 +1365,5 @@ Test 022 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 17:27:38 UTC 2021
-Elapsed time: 00h:48m:14s. Have a nice day!
+Thu Jan  7 17:57:15 UTC 2021
+Elapsed time: 01h:33m:17s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Wed Jan  6 16:38:30 UTC 2021
+Thu Jan  7 16:23:37 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_read_inc_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_read_inc_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -450,7 +450,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf024.nc ............ALT CHECK......OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_ca_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lndp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_lndp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_iau_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_iau_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lheatstrg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_lheatstrg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmprad_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1000,7 +1000,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1049,7 +1049,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1098,7 +1098,7 @@ Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_multigases_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_multigases_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1172,7 +1172,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_control_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1240,7 +1240,7 @@ Test 021 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_stretched_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1296,7 +1296,7 @@ Test 022 fv3_ccpp_stretched PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_stretched_nest_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1363,7 +1363,7 @@ Test 023 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_regional_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1374,7 +1374,7 @@ Test 024 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_restart_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_regional_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1383,7 +1383,7 @@ Test 025 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_regional_quilt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1394,7 +1394,7 @@ Test 026 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1405,7 +1405,7 @@ Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_control_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_control_debug_prod
 Checking test 028 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1435,7 +1435,7 @@ Test 028 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_stretched_nest_debug_prod
 Checking test 029 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1455,7 +1455,7 @@ Test 029 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmp_prod
 Checking test 030 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1503,7 +1503,7 @@ Test 030 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1551,7 +1551,7 @@ Test 031 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1599,7 +1599,7 @@ Test 032 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_csawmg_prod
 Checking test 033 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1647,7 +1647,7 @@ Test 033 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_satmedmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_satmedmf_prod
 Checking test 034 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1695,7 +1695,7 @@ Test 034 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmfq_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_satmedmfq_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_satmedmfq_prod
 Checking test 035 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1743,7 +1743,7 @@ Test 035 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1791,7 +1791,7 @@ Test 036 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1843,7 +1843,7 @@ Test 037 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_cpt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_cpt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_cpt_prod
 Checking test 038 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1897,7 +1897,7 @@ Test 038 fv3_ccpp_cpt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gsd_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gsd_prod
 Checking test 039 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1989,7 +1989,7 @@ Test 039 fv3_ccpp_gsd PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rap_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_rap_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_rap_prod
 Checking test 040 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2057,7 +2057,7 @@ Test 040 fv3_ccpp_rap PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_hrrr_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_hrrr_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_hrrr_prod
 Checking test 041 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2125,7 +2125,7 @@ Test 041 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_thompson_prod
 Checking test 042 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2193,7 +2193,7 @@ Test 042 fv3_ccpp_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_thompson_no_aero_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_thompson_no_aero_prod
 Checking test 043 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2261,7 +2261,7 @@ Test 043 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_rrfs_v1beta_prod
 Checking test 044 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2329,7 +2329,7 @@ Test 044 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v15p2_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v15p2_prod
 Checking test 045 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2397,7 +2397,7 @@ Test 045 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_prod
 Checking test 046 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2477,7 +2477,7 @@ Test 046 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2527,7 +2527,7 @@ Test 047 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 048 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2595,7 +2595,7 @@ Test 048 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2663,7 +2663,7 @@ Test 049 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 050 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2731,7 +2731,7 @@ Test 050 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2779,7 +2779,7 @@ Test 051 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2827,7 +2827,7 @@ Test 052 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gocart_clm_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gocart_clm_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gocart_clm_prod
 Checking test 053 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2875,7 +2875,7 @@ Test 053 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 054 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2943,7 +2943,7 @@ Test 054 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3011,7 +3011,7 @@ Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3029,7 +3029,7 @@ Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3097,7 +3097,7 @@ Test 057 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 058 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3165,7 +3165,7 @@ Test 058 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3233,7 +3233,7 @@ Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 060 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3301,7 +3301,7 @@ Test 060 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gsd_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gsd_debug_prod
 Checking test 061 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3369,7 +3369,7 @@ Test 061 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3437,7 +3437,7 @@ Test 062 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_thompson_debug_prod
 Checking test 063 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3505,7 +3505,7 @@ Test 063 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3573,7 +3573,7 @@ Test 064 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3641,7 +3641,7 @@ Test 065 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3709,7 +3709,7 @@ Test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3727,7 +3727,7 @@ Test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_control_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_control_prod
 Checking test 068 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3780,7 +3780,7 @@ Test 068 cpld_control PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restart_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restart_prod
 Checking test 069 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3833,7 +3833,7 @@ Test 069 cpld_restart PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_controlfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_controlfrac_prod
 Checking test 070 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3886,7 +3886,7 @@ Test 070 cpld_controlfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restartfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restartfrac_prod
 Checking test 071 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3939,7 +3939,7 @@ Test 071 cpld_restartfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_2threads_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_2threads_prod
 Checking test 072 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3992,7 +3992,7 @@ Test 072 cpld_2threads PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_decomp_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_decomp_prod
 Checking test 073 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4045,7 +4045,7 @@ Test 073 cpld_decomp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_satmedmf_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_satmedmf_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_satmedmf_prod
 Checking test 074 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4098,7 +4098,7 @@ Test 074 cpld_satmedmf PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_ca_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_ca_prod
 Checking test 075 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4151,7 +4151,7 @@ Test 075 cpld_ca PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_control_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_control_c192_prod
 Checking test 076 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4204,7 +4204,7 @@ Test 076 cpld_control_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restart_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restart_c192_prod
 Checking test 077 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4257,7 +4257,7 @@ Test 077 cpld_restart_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_controlfrac_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_controlfrac_c192_prod
 Checking test 078 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4310,7 +4310,7 @@ Test 078 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restartfrac_c192_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restartfrac_c192_prod
 Checking test 079 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4363,7 +4363,7 @@ Test 079 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_control_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_control_c384_prod
 Checking test 080 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4419,7 +4419,7 @@ Test 080 cpld_control_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restart_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restart_c384_prod
 Checking test 081 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4475,7 +4475,7 @@ Test 081 cpld_restart_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_controlfrac_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_controlfrac_c384_prod
 Checking test 082 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4531,7 +4531,7 @@ Test 082 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restartfrac_c384_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restartfrac_c384_prod
 Checking test 083 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4587,7 +4587,7 @@ Test 083 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_bmark_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_bmark_prod
 Checking test 084 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4643,7 +4643,7 @@ Test 084 cpld_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restart_bmark_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restart_bmark_prod
 Checking test 085 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4699,7 +4699,7 @@ Test 085 cpld_restart_bmark PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_bmarkfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_bmarkfrac_prod
 Checking test 086 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4755,7 +4755,7 @@ Test 086 cpld_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restart_bmarkfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restart_bmarkfrac_prod
 Checking test 087 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4811,7 +4811,7 @@ Test 087 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_bmarkfrac_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_bmarkfrac_v16_prod
 Checking test 088 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4867,7 +4867,7 @@ Test 088 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_restart_bmarkfrac_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_restart_bmarkfrac_v16_prod
 Checking test 089 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4923,7 +4923,7 @@ Test 089 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_bmark_wave_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_bmark_wave_prod
 Checking test 090 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4982,7 +4982,7 @@ Test 090 cpld_bmark_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_bmarkfrac_wave_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_bmarkfrac_wave_prod
 Checking test 091 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5041,7 +5041,7 @@ Test 091 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_bmarkfrac_wave_v16_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_bmarkfrac_wave_v16_prod
 Checking test 092 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -5100,7 +5100,7 @@ Test 092 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_debug_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_debug_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_debug_prod
 Checking test 093 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5153,7 +5153,7 @@ Test 093 cpld_debug PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_debugfrac_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/cpld_debugfrac_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/cpld_debugfrac_prod
 Checking test 094 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5206,7 +5206,7 @@ Test 094 cpld_debugfrac PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_control_cfsr
 Checking test 095 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5215,7 +5215,7 @@ Test 095 datm_control_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_restart_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_restart_cfsr
 Checking test 096 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5224,7 +5224,7 @@ Test 096 datm_restart_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_control_gefs
 Checking test 097 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5233,7 +5233,7 @@ Test 097 datm_control_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_bulk_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_bulk_cfsr
 Checking test 098 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5242,7 +5242,7 @@ Test 098 datm_bulk_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_bulk_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_bulk_gefs
 Checking test 099 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5251,7 +5251,7 @@ Test 099 datm_bulk_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_mx025_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_mx025_cfsr
 Checking test 100 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5263,7 +5263,7 @@ Test 100 datm_mx025_cfsr PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_mx025_gefs
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_mx025_gefs
 Checking test 101 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5275,7 +5275,7 @@ Test 101 datm_mx025_gefs PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_debug_cfsr
-working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_3299/datm_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_186263/datm_debug_cfsr
 Checking test 102 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5284,5 +5284,5 @@ Test 102 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 18:05:46 UTC 2021
-Elapsed time: 01h:27m:17s. Have a nice day!
+Thu Jan  7 19:17:41 UTC 2021
+Elapsed time: 02h:54m:04s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,9 +1,9 @@
-Wed Jan  6 22:03:47 GMT 2021
+Thu Jan  7 22:03:11 GMT 2021
 Start Regression test
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_decomp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc ............ALT CHECK......OK
  Comparing atmos_4xdaily.tile2.nc ............ALT CHECK......OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_2threads_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_restart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_read_inc_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_read_inc_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -450,7 +450,7 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
  Comparing RESTART/fv_core.res.tile1.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_stochy_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_ca_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_ca_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lndp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_lndp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_iau_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_iau_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lheatstrg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_lheatstrg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_multigases_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_multigases_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1025,7 +1025,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_control_32bit_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1093,7 +1093,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_stretched_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1149,7 +1149,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_stretched_nest_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1216,18 +1216,18 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_control_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_regional_control_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
- Comparing atmos_4xdaily.nc .........OK
- Comparing fv3_history2d.nc .........OK
- Comparing fv3_history.nc .........OK
+ Comparing atmos_4xdaily.nc ............ALT CHECK......OK
+ Comparing fv3_history2d.nc ............ALT CHECK......OK
+ Comparing fv3_history.nc ............ALT CHECK......OK
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
+ Comparing RESTART/fv_tracer.res.tile1_new.nc ............ALT CHECK......OK
 Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_restart_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_regional_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1236,7 +1236,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_regional_quilt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1247,18 +1247,18 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
+ Comparing dynf024.nc ............ALT CHECK......OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_control_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1308,7 +1308,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfdlmp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1356,7 +1356,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1404,7 +1404,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1452,7 +1452,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_csawmg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1500,7 +1500,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmf_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_satmedmf_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1548,7 +1548,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmfq_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_satmedmfq_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1596,7 +1596,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1644,7 +1644,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1696,7 +1696,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_cpt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_cpt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1750,7 +1750,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gsd_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_thompson_prod
 Checking test 037 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 037 fv3_ccpp_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_thompson_no_aero_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_thompson_no_aero_prod
 Checking test 038 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 038 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v15p2_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v15p2_prod
 Checking test 039 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 039 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_prod
 Checking test 040 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2126,7 +2126,7 @@ Test 040 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 041 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2176,7 +2176,7 @@ Test 041 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 042 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2244,7 +2244,7 @@ Test 042 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 043 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2312,7 +2312,7 @@ Test 043 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 044 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 044 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 045 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2428,7 +2428,7 @@ Test 045 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 046 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2476,7 +2476,7 @@ Test 046 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gocart_clm_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gocart_clm_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gocart_clm_prod
 Checking test 047 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2524,7 +2524,7 @@ Test 047 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 048 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2592,7 +2592,7 @@ Test 048 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 049 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2660,7 +2660,7 @@ Test 049 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2678,7 +2678,7 @@ Test 050 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 051 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2746,7 +2746,7 @@ Test 051 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 052 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2814,7 +2814,7 @@ Test 052 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2882,7 +2882,7 @@ Test 053 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 054 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2950,7 +2950,7 @@ Test 054 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gsd_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gsd_debug_prod
 Checking test 055 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3018,7 +3018,7 @@ Test 055 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 056 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3086,7 +3086,7 @@ Test 056 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_thompson_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_thompson_debug_prod
 Checking test 057 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3154,7 +3154,7 @@ Test 057 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 058 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3222,7 +3222,7 @@ Test 058 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 059 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3290,7 +3290,7 @@ Test 059 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 060 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3358,7 +3358,7 @@ Test 060 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /lfs4/HFIP/hfv3gfs/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_205832/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /lfs4/HFIP/hfv3gfs/Dom.Heinzeller/RT_RUNDIRS/Dom.Heinzeller/FV3_RT/rt_304085/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 061 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3376,5 +3376,5 @@ Test 061 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 23:41:16 GMT 2021
-Elapsed time: 01h:37m:29s. Have a nice day!
+Thu Jan  7 23:40:47 GMT 2021
+Elapsed time: 01h:37m:37s. Have a nice day!

--- a/tests/RegressionTests_orion.intel.log
+++ b/tests/RegressionTests_orion.intel.log
@@ -1,9 +1,9 @@
-Wed Jan  6 15:41:05 CST 2021
+Thu Jan  7 15:36:40 CST 2021
 Start Regression test
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_restart_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_read_inc_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_read_inc_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stochy_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_stochy_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_ca_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_ca_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lndp_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_lndp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_iau_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_iau_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_lheatstrg_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_lheatstrg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmprad_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1000,7 +1000,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1049,7 +1049,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_wrtGauss_nemsio_c768_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_wrtGauss_nemsio_c768_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_wrtGauss_nemsio_c768_prod
 Checking test 019 fv3_ccpp_wrtGauss_nemsio_c768 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1098,7 +1098,7 @@ Test 019 fv3_ccpp_wrtGauss_nemsio_c768 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_multigases_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_multigases_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_multigases_prod
 Checking test 020 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1172,7 +1172,7 @@ Test 020 fv3_ccpp_multigases PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_32bit_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_control_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_control_32bit_prod
 Checking test 021 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1240,7 +1240,7 @@ Test 021 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_stretched_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_stretched_prod
 Checking test 022 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1296,7 +1296,7 @@ Test 022 fv3_ccpp_stretched PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_stretched_nest_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_stretched_nest_prod
 Checking test 023 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1363,7 +1363,7 @@ Test 023 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_regional_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_regional_control_prod
 Checking test 024 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1374,7 +1374,7 @@ Test 024 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_restart_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_regional_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_regional_restart_prod
 Checking test 025 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1383,7 +1383,7 @@ Test 025 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_regional_quilt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_regional_quilt_prod
 Checking test 026 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1394,7 +1394,7 @@ Test 026 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 027 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1405,7 +1405,7 @@ Test 027 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_control_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_control_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_control_debug_prod
 Checking test 028 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1435,7 +1435,7 @@ Test 028 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_stretched_nest_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_stretched_nest_debug_prod
 Checking test 029 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1455,7 +1455,7 @@ Test 029 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmp_prod
 Checking test 030 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1503,7 +1503,7 @@ Test 030 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 031 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1551,7 +1551,7 @@ Test 031 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 032 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1599,7 +1599,7 @@ Test 032 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_csawmg_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_csawmg_prod
 Checking test 033 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1647,7 +1647,7 @@ Test 033 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmf_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_satmedmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_satmedmf_prod
 Checking test 034 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1695,7 +1695,7 @@ Test 034 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_satmedmfq_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_satmedmfq_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_satmedmfq_prod
 Checking test 035 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1743,7 +1743,7 @@ Test 035 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 036 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1791,7 +1791,7 @@ Test 036 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 037 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1843,7 +1843,7 @@ Test 037 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_cpt_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_cpt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_cpt_prod
 Checking test 038 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1897,7 +1897,7 @@ Test 038 fv3_ccpp_cpt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gsd_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gsd_prod
 Checking test 039 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1989,7 +1989,7 @@ Test 039 fv3_ccpp_gsd PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rap_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_rap_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_rap_prod
 Checking test 040 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2057,7 +2057,7 @@ Test 040 fv3_ccpp_rap PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_hrrr_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_hrrr_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_hrrr_prod
 Checking test 041 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2125,7 +2125,7 @@ Test 041 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_thompson_prod
 Checking test 042 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2193,7 +2193,7 @@ Test 042 fv3_ccpp_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_thompson_no_aero_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_thompson_no_aero_prod
 Checking test 043 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2261,7 +2261,7 @@ Test 043 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_rrfs_v1beta_prod
 Checking test 044 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2329,7 +2329,7 @@ Test 044 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v15p2_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v15p2_prod
 Checking test 045 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2397,7 +2397,7 @@ Test 045 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_prod
 Checking test 046 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2477,7 +2477,7 @@ Test 046 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2527,7 +2527,7 @@ Test 047 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 048 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2595,7 +2595,7 @@ Test 048 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 049 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2663,7 +2663,7 @@ Test 049 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 050 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2731,7 +2731,7 @@ Test 050 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmg_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 051 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2779,7 +2779,7 @@ Test 051 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfsv16_csawmgt_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 052 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2827,7 +2827,7 @@ Test 052 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gocart_clm_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gocart_clm_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gocart_clm_prod
 Checking test 053 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2875,7 +2875,7 @@ Test 053 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 054 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2943,7 +2943,7 @@ Test 054 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 055 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3011,7 +3011,7 @@ Test 055 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3029,7 +3029,7 @@ Test 056 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 057 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3097,7 +3097,7 @@ Test 057 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 058 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3165,7 +3165,7 @@ Test 058 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3233,7 +3233,7 @@ Test 059 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 060 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3301,7 +3301,7 @@ Test 060 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gsd_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gsd_debug_prod
 Checking test 061 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3369,7 +3369,7 @@ Test 061 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 062 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3437,7 +3437,7 @@ Test 062 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_thompson_debug_prod
 Checking test 063 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3505,7 +3505,7 @@ Test 063 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 064 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3573,7 +3573,7 @@ Test 064 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 065 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3641,7 +3641,7 @@ Test 065 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3709,7 +3709,7 @@ Test 066 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3727,7 +3727,7 @@ Test 067 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_control_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_control_prod
 Checking test 068 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3780,7 +3780,7 @@ Test 068 cpld_control PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restart_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restart_prod
 Checking test 069 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3833,7 +3833,7 @@ Test 069 cpld_restart PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_controlfrac_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_controlfrac_prod
 Checking test 070 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3886,7 +3886,7 @@ Test 070 cpld_controlfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restartfrac_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restartfrac_prod
 Checking test 071 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3939,7 +3939,7 @@ Test 071 cpld_restartfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_2threads_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_2threads_prod
 Checking test 072 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3992,7 +3992,7 @@ Test 072 cpld_2threads PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_decomp_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_decomp_prod
 Checking test 073 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4045,7 +4045,7 @@ Test 073 cpld_decomp PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_satmedmf_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_satmedmf_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_satmedmf_prod
 Checking test 074 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4098,7 +4098,7 @@ Test 074 cpld_satmedmf PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_ca_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_ca_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_ca_prod
 Checking test 075 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4151,7 +4151,7 @@ Test 075 cpld_ca PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_control_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_control_c192_prod
 Checking test 076 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4204,7 +4204,7 @@ Test 076 cpld_control_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c192_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restart_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restart_c192_prod
 Checking test 077 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4257,7 +4257,7 @@ Test 077 cpld_restart_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_controlfrac_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_controlfrac_c192_prod
 Checking test 078 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4310,7 +4310,7 @@ Test 078 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c192_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restartfrac_c192_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restartfrac_c192_prod
 Checking test 079 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4363,7 +4363,7 @@ Test 079 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_control_c384_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_control_c384_prod
 Checking test 080 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4419,7 +4419,7 @@ Test 080 cpld_control_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_control_c384_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restart_c384_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restart_c384_prod
 Checking test 081 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4475,7 +4475,7 @@ Test 081 cpld_restart_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_controlfrac_c384_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_controlfrac_c384_prod
 Checking test 082 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4531,7 +4531,7 @@ Test 082 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_controlfrac_c384_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restartfrac_c384_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restartfrac_c384_prod
 Checking test 083 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4587,7 +4587,7 @@ Test 083 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_bmark_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_bmark_prod
 Checking test 084 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4643,7 +4643,7 @@ Test 084 cpld_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restart_bmark_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restart_bmark_prod
 Checking test 085 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4699,7 +4699,7 @@ Test 085 cpld_restart_bmark PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_bmarkfrac_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_bmarkfrac_prod
 Checking test 086 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4755,7 +4755,7 @@ Test 086 cpld_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restart_bmarkfrac_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restart_bmarkfrac_prod
 Checking test 087 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4811,7 +4811,7 @@ Test 087 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_bmarkfrac_v16_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_bmarkfrac_v16_prod
 Checking test 088 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4867,7 +4867,7 @@ Test 088 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_v16_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_restart_bmarkfrac_v16_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_restart_bmarkfrac_v16_prod
 Checking test 089 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4923,7 +4923,7 @@ Test 089 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmark_wave_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_bmark_wave_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_bmark_wave_prod
 Checking test 090 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4982,7 +4982,7 @@ Test 090 cpld_bmark_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_wave_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_bmarkfrac_wave_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_bmarkfrac_wave_prod
 Checking test 091 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -5041,7 +5041,7 @@ Test 091 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_bmarkfrac_wave_v16_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_bmarkfrac_wave_v16_prod
 Checking test 092 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -5100,7 +5100,7 @@ Test 092 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_debug_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_debug_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_debug_prod
 Checking test 093 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5153,7 +5153,7 @@ Test 093 cpld_debug PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/cpld_debugfrac_ccpp
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/cpld_debugfrac_prod
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/cpld_debugfrac_prod
 Checking test 094 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5206,7 +5206,7 @@ Test 094 cpld_debugfrac PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_control_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_control_cfsr
 Checking test 095 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5215,7 +5215,7 @@ Test 095 datm_control_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_cfsr
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_restart_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_restart_cfsr
 Checking test 096 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5224,7 +5224,7 @@ Test 096 datm_restart_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_control_gefs
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_control_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_control_gefs
 Checking test 097 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5233,7 +5233,7 @@ Test 097 datm_control_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_bulk_cfsr
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_bulk_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_bulk_cfsr
 Checking test 098 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5242,7 +5242,7 @@ Test 098 datm_bulk_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_bulk_gefs
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_bulk_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_bulk_gefs
 Checking test 099 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5251,7 +5251,7 @@ Test 099 datm_bulk_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_mx025_cfsr
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_mx025_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_mx025_cfsr
 Checking test 100 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5263,7 +5263,7 @@ Test 100 datm_mx025_cfsr PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_mx025_gefs
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_mx025_gefs
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_mx025_gefs
 Checking test 101 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5275,7 +5275,7 @@ Test 101 datm_mx025_gefs PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/INTEL/datm_debug_cfsr
-working dir  = /work/noaa/stmp/djovic/stmp/djovic/FV3_RT/rt_299167/datm_debug_cfsr
+working dir  = /work/noaa/stmp/dheinzel/stmp/dheinzel/FV3_RT/rt_111651/datm_debug_cfsr
 Checking test 102 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5284,5 +5284,5 @@ Test 102 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 17:01:22 CST 2021
-Elapsed time: 01h:20m:17s. Have a nice day!
+Thu Jan  7 16:59:10 CST 2021
+Elapsed time: 01h:22m:31s. Have a nice day!

--- a/tests/RegressionTests_wcoss_cray.log
+++ b/tests/RegressionTests_wcoss_cray.log
@@ -1,9 +1,9 @@
-Wed Jan  6 18:17:45 UTC 2021
+Fri Jan  8 14:11:04 UTC 2021
 Start Regression test
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_control_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_decomp_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_2threads_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_restart_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_read_inc_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_stochy_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_ca_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_ca_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_lndp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_lndp_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_iau_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_iau_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_lheatstrg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_multigases_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_multigases_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_multigases_prod
 Checking test 017 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1025,7 +1025,7 @@ Test 017 fv3_ccpp_multigases PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_control_32bit_prod
 Checking test 018 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1093,7 +1093,7 @@ Test 018 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stretched_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_stretched_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_stretched_prod
 Checking test 019 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1149,7 +1149,7 @@ Test 019 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stretched_nest_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_stretched_nest_prod
 Checking test 020 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1216,7 +1216,7 @@ Test 020 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_control_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_regional_control_prod
 Checking test 021 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1227,7 +1227,7 @@ Test 021 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_restart_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_regional_restart_prod
 Checking test 022 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1236,7 +1236,7 @@ Test 022 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_quilt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_regional_quilt_prod
 Checking test 023 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1247,7 +1247,7 @@ Test 023 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 024 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1258,7 +1258,7 @@ Test 024 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_control_debug_prod
 Checking test 025 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1288,7 +1288,7 @@ Test 025 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_stretched_nest_debug_prod
 Checking test 026 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1308,7 +1308,7 @@ Test 026 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfdlmp_prod
 Checking test 027 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1356,7 +1356,7 @@ Test 027 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 028 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1404,7 +1404,7 @@ Test 028 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 029 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1452,7 +1452,7 @@ Test 029 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_csawmg_prod
 Checking test 030 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1500,7 +1500,7 @@ Test 030 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_satmedmf_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_satmedmf_prod
 Checking test 031 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1548,7 +1548,7 @@ Test 031 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_satmedmfq_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_satmedmfq_prod
 Checking test 032 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1596,7 +1596,7 @@ Test 032 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 033 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1644,7 +1644,7 @@ Test 033 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 034 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1696,7 +1696,7 @@ Test 034 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_cpt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_cpt_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_cpt_prod
 Checking test 035 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1750,7 +1750,7 @@ Test 035 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gsd_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gsd_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gsd_prod
 Checking test 036 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1842,7 +1842,7 @@ Test 036 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_rap_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_rap_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_rap_prod
 Checking test 037 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1910,7 +1910,7 @@ Test 037 fv3_ccpp_rap PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_hrrr_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_hrrr_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_hrrr_prod
 Checking test 038 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1978,7 +1978,7 @@ Test 038 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_thompson_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_thompson_prod
 Checking test 039 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2046,7 +2046,7 @@ Test 039 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_thompson_no_aero_prod
 Checking test 040 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2114,7 +2114,7 @@ Test 040 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_rrfs_v1beta_prod
 Checking test 041 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2182,7 +2182,7 @@ Test 041 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v15p2_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v15p2_prod
 Checking test 042 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2250,7 +2250,7 @@ Test 042 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_prod
 Checking test 043 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2330,7 +2330,7 @@ Test 043 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 044 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2380,7 +2380,7 @@ Test 044 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 045 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2448,7 +2448,7 @@ Test 045 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 046 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2516,7 +2516,7 @@ Test 046 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2584,7 +2584,7 @@ Test 047 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 048 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2632,7 +2632,7 @@ Test 048 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 049 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2680,7 +2680,7 @@ Test 049 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gocart_clm_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gocart_clm_prod
 Checking test 050 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2728,7 +2728,7 @@ Test 050 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_flake_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 051 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2796,7 +2796,7 @@ Test 051 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 052 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2864,7 +2864,7 @@ Test 052 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2882,7 +2882,7 @@ Test 053 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 054 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2950,7 +2950,7 @@ Test 054 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 055 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3018,7 +3018,7 @@ Test 055 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 056 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3086,7 +3086,7 @@ Test 056 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 057 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3154,7 +3154,7 @@ Test 057 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gsd_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gsd_debug_prod
 Checking test 058 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3222,7 +3222,7 @@ Test 058 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 059 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3290,7 +3290,7 @@ Test 059 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_thompson_debug_prod
 Checking test 060 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3358,7 +3358,7 @@ Test 060 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 061 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3426,7 +3426,7 @@ Test 061 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 062 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3494,7 +3494,7 @@ Test 062 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3562,7 +3562,7 @@ Test 063 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/hps3/emc/nems/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/hps3/stmp/Dusan.Jovic/FV3_RT/rt_30423/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/hps3/stmp/Denise.Worthen/FV3_RT/rt_11930/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3580,5 +3580,5 @@ Test 064 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 18:59:33 UTC 2021
-Elapsed time: 00h:41m:49s. Have a nice day!
+Fri Jan  8 14:51:01 UTC 2021
+Elapsed time: 00h:39m:58s. Have a nice day!

--- a/tests/RegressionTests_wcoss_dell_p3.log
+++ b/tests/RegressionTests_wcoss_dell_p3.log
@@ -1,9 +1,9 @@
-Wed Jan  6 19:39:15 UTC 2021
+Fri Jan  8 14:15:55 UTC 2021
 Start Regression test
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_control_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -71,7 +71,7 @@ Test 001 fv3_ccpp_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_decomp_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -139,7 +139,7 @@ Test 002 fv3_ccpp_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_2threads_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -207,7 +207,7 @@ Test 003 fv3_ccpp_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_restart_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -275,7 +275,7 @@ Test 004 fv3_ccpp_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_read_inc_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_read_inc_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -343,7 +343,7 @@ Test 005 fv3_ccpp_read_inc PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -391,7 +391,7 @@ Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_wrtGauss_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -439,7 +439,7 @@ Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_wrtGauss_netcdf_parallel_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_wrtGauss_netcdf_parallel_prod
 Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -448,8 +448,8 @@ Checking test 008 fv3_ccpp_wrtGauss_netcdf_parallel results ....
  Comparing atmos_4xdaily.tile5.nc .........OK
  Comparing atmos_4xdaily.tile6.nc .........OK
  Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf024.nc ............ALT CHECK......OK
- Comparing dynf000.nc .........OK
+ Comparing phyf024.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf024.nc .........OK
  Comparing RESTART/coupler.res .........OK
  Comparing RESTART/fv_core.res.nc .........OK
@@ -487,7 +487,7 @@ Test 008 fv3_ccpp_wrtGauss_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_wrtGlatlon_netcdf_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 009 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -535,7 +535,7 @@ Test 009 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_nemsio_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_wrtGauss_nemsio_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -583,7 +583,7 @@ Test 010 fv3_ccpp_wrtGauss_nemsio PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_wrtGauss_nemsio_c192_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 011 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -631,7 +631,7 @@ Test 011 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_stochy_prod
 Checking test 012 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -699,7 +699,7 @@ Test 012 fv3_ccpp_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_ca_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -767,7 +767,7 @@ Test 013 fv3_ccpp_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_lndp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_lndp_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_lndp_prod
 Checking test 014 fv3_ccpp_lndp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -835,7 +835,7 @@ Test 014 fv3_ccpp_lndp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_iau_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_iau_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_iau_prod
 Checking test 015 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -903,7 +903,7 @@ Test 015 fv3_ccpp_iau PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_lheatstrg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_lheatstrg_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_lheatstrg_prod
 Checking test 016 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -951,7 +951,7 @@ Test 016 fv3_ccpp_lheatstrg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmprad_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmprad_prod
 Checking test 017 fv3_ccpp_gfdlmprad results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1000,7 +1000,7 @@ Test 017 fv3_ccpp_gfdlmprad PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_atmwav_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmprad_atmwav_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmprad_atmwav_prod
 Checking test 018 fv3_ccpp_gfdlmprad_atmwav results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1049,7 +1049,7 @@ Test 018 fv3_ccpp_gfdlmprad_atmwav PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_multigases_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_multigases_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_multigases_prod
 Checking test 019 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1123,7 +1123,7 @@ Test 019 fv3_ccpp_multigases PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_control_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_control_32bit_prod
 Checking test 020 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1191,7 +1191,7 @@ Test 020 fv3_ccpp_control_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stretched_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_stretched_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_stretched_prod
 Checking test 021 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1247,7 +1247,7 @@ Test 021 fv3_ccpp_stretched PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stretched_nest_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_stretched_nest_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_stretched_nest_prod
 Checking test 022 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1314,7 +1314,7 @@ Test 022 fv3_ccpp_stretched_nest PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_regional_control_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_regional_control_prod
 Checking test 023 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1325,7 +1325,7 @@ Test 023 fv3_ccpp_regional_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_restart_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_regional_restart_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_regional_restart_prod
 Checking test 024 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1334,7 +1334,7 @@ Test 024 fv3_ccpp_regional_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_quilt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_regional_quilt_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_regional_quilt_prod
 Checking test 025 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1345,18 +1345,18 @@ Test 025 fv3_ccpp_regional_quilt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_regional_quilt_netcdf_parallel_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_regional_quilt_netcdf_parallel_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_regional_quilt_netcdf_parallel_prod
 Checking test 026 fv3_ccpp_regional_quilt_netcdf_parallel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
+ Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 Test 026 fv3_ccpp_regional_quilt_netcdf_parallel PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_control_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_control_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_control_debug_prod
 Checking test 027 fv3_ccpp_control_debug results ....
  Comparing phyf000.tile1.nc .........OK
  Comparing phyf000.tile2.nc .........OK
@@ -1386,7 +1386,7 @@ Test 027 fv3_ccpp_control_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_stretched_nest_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_stretched_nest_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_stretched_nest_debug_prod
 Checking test 028 fv3_ccpp_stretched_nest_debug results ....
  Comparing fv3_history2d.nest02.tile7.nc .........OK
  Comparing fv3_history2d.tile1.nc .........OK
@@ -1406,7 +1406,7 @@ Test 028 fv3_ccpp_stretched_nest_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmp_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmp_prod
 Checking test 029 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1454,7 +1454,7 @@ Test 029 fv3_ccpp_gfdlmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_gwd_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmprad_gwd_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 030 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1502,7 +1502,7 @@ Test 030 fv3_ccpp_gfdlmprad_gwd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmprad_noahmp_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 031 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1550,7 +1550,7 @@ Test 031 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_csawmg_prod
 Checking test 032 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1598,7 +1598,7 @@ Test 032 fv3_ccpp_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_satmedmf_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_satmedmf_prod
 Checking test 033 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1646,7 +1646,7 @@ Test 033 fv3_ccpp_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_satmedmfq_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_satmedmfq_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_satmedmfq_prod
 Checking test 034 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1694,7 +1694,7 @@ Test 034 fv3_ccpp_satmedmfq PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmp_32bit_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmp_32bit_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 035 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1742,7 +1742,7 @@ Test 035 fv3_ccpp_gfdlmp_32bit PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfdlmprad_32bit_post_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 036 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1794,7 +1794,7 @@ Test 036 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_cpt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_cpt_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_cpt_prod
 Checking test 037 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1848,7 +1848,7 @@ Test 037 fv3_ccpp_cpt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gsd_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gsd_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gsd_prod
 Checking test 038 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1940,7 +1940,7 @@ Test 038 fv3_ccpp_gsd PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_rap_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_rap_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_rap_prod
 Checking test 039 fv3_ccpp_rap results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2008,7 +2008,7 @@ Test 039 fv3_ccpp_rap PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_hrrr_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_hrrr_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_hrrr_prod
 Checking test 040 fv3_ccpp_hrrr results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2076,7 +2076,7 @@ Test 040 fv3_ccpp_hrrr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_thompson_prod
 Checking test 041 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2144,7 +2144,7 @@ Test 041 fv3_ccpp_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_no_aero_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_thompson_no_aero_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_thompson_no_aero_prod
 Checking test 042 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2212,7 +2212,7 @@ Test 042 fv3_ccpp_thompson_no_aero PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_rrfs_v1beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_rrfs_v1beta_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_rrfs_v1beta_prod
 Checking test 043 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2280,7 +2280,7 @@ Test 043 fv3_ccpp_rrfs_v1beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v15p2_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v15p2_prod
 Checking test 044 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2348,7 +2348,7 @@ Test 044 fv3_ccpp_gfs_v15p2 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_prod
 Checking test 045 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2428,7 +2428,7 @@ Test 045 fv3_ccpp_gfs_v16beta PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_restart_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_restart_prod
 Checking test 046 fv3_ccpp_gfs_v16beta_restart results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -2478,7 +2478,7 @@ Test 046 fv3_ccpp_gfs_v16beta_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_stochy_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_stochy_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_stochy_prod
 Checking test 047 fv3_ccpp_gfs_v16beta_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2546,7 +2546,7 @@ Test 047 fv3_ccpp_gfs_v16beta_stochy PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v15p2_RRTMGP_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v15p2_RRTMGP_prod
 Checking test 048 fv3_ccpp_gfs_v15p2_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2614,7 +2614,7 @@ Test 048 fv3_ccpp_gfs_v15p2_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_RRTMGP_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_RRTMGP_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_RRTMGP_prod
 Checking test 049 fv3_ccpp_gfs_v16beta_RRTMGP results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2682,7 +2682,7 @@ Test 049 fv3_ccpp_gfs_v16beta_RRTMGP PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfsv16_csawmg_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfsv16_csawmg_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfsv16_csawmg_prod
 Checking test 050 fv3_ccpp_gfsv16_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2730,7 +2730,7 @@ Test 050 fv3_ccpp_gfsv16_csawmg PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfsv16_csawmgt_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfsv16_csawmgt_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfsv16_csawmgt_prod
 Checking test 051 fv3_ccpp_gfsv16_csawmgt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2778,7 +2778,7 @@ Test 051 fv3_ccpp_gfsv16_csawmgt PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gocart_clm_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gocart_clm_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gocart_clm_prod
 Checking test 052 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2826,7 +2826,7 @@ Test 052 fv3_ccpp_gocart_clm PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_flake_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_flake_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 053 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2894,7 +2894,7 @@ Test 053 fv3_ccpp_gfs_v16beta_flake PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_HAFS_v0_hwrf_thompson_prod
 Checking test 054 fv3_ccpp_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2962,7 +2962,7 @@ Test 054 fv3_ccpp_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/ESG_HAFS_v0_HWRF_thompson_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_prod
 Checking test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -2980,7 +2980,7 @@ Test 055 fv3_ccpp_esg_HAFS_v0_hwrf_thompson PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v15p2_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 056 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3048,7 +3048,7 @@ Test 056 fv3_ccpp_gfs_v15p2_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 057 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3116,7 +3116,7 @@ Test 057 fv3_ccpp_gfs_v16beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v15p2_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v15p2_RRTMGP_debug_prod
 Checking test 058 fv3_ccpp_gfs_v15p2_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3184,7 +3184,7 @@ Test 058 fv3_ccpp_gfs_v15p2_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gfs_v16beta_RRTMGP_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gfs_v16beta_RRTMGP_debug_prod
 Checking test 059 fv3_ccpp_gfs_v16beta_RRTMGP_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3252,7 +3252,7 @@ Test 059 fv3_ccpp_gfs_v16beta_RRTMGP_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gsd_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gsd_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gsd_debug_prod
 Checking test 060 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3320,7 +3320,7 @@ Test 060 fv3_ccpp_gsd_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_gsd_diag3d_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_gsd_diag3d_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 061 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3388,7 +3388,7 @@ Test 061 fv3_ccpp_gsd_diag3d_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_thompson_debug_prod
 Checking test 062 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3456,7 +3456,7 @@ Test 062 fv3_ccpp_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_thompson_no_aero_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_thompson_no_aero_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 063 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3524,7 +3524,7 @@ Test 063 fv3_ccpp_thompson_no_aero_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_rrfs_v1beta_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 064 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3592,7 +3592,7 @@ Test 064 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 065 fv3_ccpp_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -3660,7 +3660,7 @@ Test 065 fv3_ccpp_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/ESG_HAFS_v0_HWRF_thompson_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug_prod
 Checking test 066 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3678,7 +3678,7 @@ Test 066 fv3_ccpp_esg_HAFS_v0_hwrf_thompson_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_control_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_control_prod
 Checking test 067 cpld_control results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3731,7 +3731,7 @@ Test 067 cpld_control PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restart_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restart_prod
 Checking test 068 cpld_restart results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3784,7 +3784,7 @@ Test 068 cpld_restart PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_controlfrac_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_controlfrac_prod
 Checking test 069 cpld_controlfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3837,7 +3837,7 @@ Test 069 cpld_controlfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_controlfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restartfrac_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restartfrac_prod
 Checking test 070 cpld_restartfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3890,7 +3890,7 @@ Test 070 cpld_restartfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_2threads_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_2threads_prod
 Checking test 071 cpld_2threads results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3943,7 +3943,7 @@ Test 071 cpld_2threads PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_decomp_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_decomp_prod
 Checking test 072 cpld_decomp results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -3996,7 +3996,7 @@ Test 072 cpld_decomp PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_satmedmf_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_satmedmf_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_satmedmf_prod
 Checking test 073 cpld_satmedmf results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4049,7 +4049,7 @@ Test 073 cpld_satmedmf PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_ca_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_ca_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_ca_prod
 Checking test 074 cpld_ca results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4102,7 +4102,7 @@ Test 074 cpld_ca PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_control_c192_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_control_c192_prod
 Checking test 075 cpld_control_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4155,7 +4155,7 @@ Test 075 cpld_control_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restart_c192_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restart_c192_prod
 Checking test 076 cpld_restart_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4208,7 +4208,7 @@ Test 076 cpld_restart_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_controlfrac_c192_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_controlfrac_c192_prod
 Checking test 077 cpld_controlfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4261,7 +4261,7 @@ Test 077 cpld_controlfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_controlfrac_c192_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restartfrac_c192_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restartfrac_c192_prod
 Checking test 078 cpld_restartfrac_c192 results ....
  Comparing phyf048.tile1.nc .........OK
  Comparing phyf048.tile2.nc .........OK
@@ -4314,7 +4314,7 @@ Test 078 cpld_restartfrac_c192 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_control_c384_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_control_c384_prod
 Checking test 079 cpld_control_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4370,7 +4370,7 @@ Test 079 cpld_control_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_control_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restart_c384_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restart_c384_prod
 Checking test 080 cpld_restart_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4426,7 +4426,7 @@ Test 080 cpld_restart_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_controlfrac_c384_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_controlfrac_c384_prod
 Checking test 081 cpld_controlfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4482,7 +4482,7 @@ Test 081 cpld_controlfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_controlfrac_c384_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restartfrac_c384_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restartfrac_c384_prod
 Checking test 082 cpld_restartfrac_c384 results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4538,7 +4538,7 @@ Test 082 cpld_restartfrac_c384 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_bmark_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_bmark_prod
 Checking test 083 cpld_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4594,7 +4594,7 @@ Test 083 cpld_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmark_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restart_bmark_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restart_bmark_prod
 Checking test 084 cpld_restart_bmark results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4650,7 +4650,7 @@ Test 084 cpld_restart_bmark PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_bmarkfrac_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_bmarkfrac_prod
 Checking test 085 cpld_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4706,7 +4706,7 @@ Test 085 cpld_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmarkfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restart_bmarkfrac_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restart_bmarkfrac_prod
 Checking test 086 cpld_restart_bmarkfrac results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4762,7 +4762,7 @@ Test 086 cpld_restart_bmarkfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_bmarkfrac_v16_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_bmarkfrac_v16_prod
 Checking test 087 cpld_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4818,7 +4818,7 @@ Test 087 cpld_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmarkfrac_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_restart_bmarkfrac_v16_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_restart_bmarkfrac_v16_prod
 Checking test 088 cpld_restart_bmarkfrac_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -4874,7 +4874,7 @@ Test 088 cpld_restart_bmarkfrac_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmark_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_bmark_wave_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_bmark_wave_prod
 Checking test 089 cpld_bmark_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4933,7 +4933,7 @@ Test 089 cpld_bmark_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmarkfrac_wave_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_bmarkfrac_wave_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_bmarkfrac_wave_prod
 Checking test 090 cpld_bmarkfrac_wave results ....
  Comparing phyf024.tile1.nc .........OK
  Comparing phyf024.tile2.nc .........OK
@@ -4992,7 +4992,7 @@ Test 090 cpld_bmarkfrac_wave PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_bmarkfrac_wave_v16_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_bmarkfrac_wave_v16_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_bmarkfrac_wave_v16_prod
 Checking test 091 cpld_bmarkfrac_wave_v16 results ....
  Comparing phyf012.tile1.nc .........OK
  Comparing phyf012.tile2.nc .........OK
@@ -5051,7 +5051,7 @@ Test 091 cpld_bmarkfrac_wave_v16 PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_debug_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_debug_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_debug_prod
 Checking test 092 cpld_debug results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5104,7 +5104,7 @@ Test 092 cpld_debug PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/cpld_debugfrac_ccpp
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/cpld_debugfrac_prod
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/cpld_debugfrac_prod
 Checking test 093 cpld_debugfrac results ....
  Comparing phyf006.tile1.nc .........OK
  Comparing phyf006.tile2.nc .........OK
@@ -5157,7 +5157,7 @@ Test 093 cpld_debugfrac PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_control_cfsr
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_control_cfsr
 Checking test 094 datm_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5166,7 +5166,7 @@ Test 094 datm_control_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_control_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_restart_cfsr
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_restart_cfsr
 Checking test 095 datm_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5175,7 +5175,7 @@ Test 095 datm_restart_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_control_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_control_gefs
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_control_gefs
 Checking test 096 datm_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5184,7 +5184,7 @@ Test 096 datm_control_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_bulk_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_bulk_cfsr
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_bulk_cfsr
 Checking test 097 datm_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5193,7 +5193,7 @@ Test 097 datm_bulk_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_bulk_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_bulk_gefs
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_bulk_gefs
 Checking test 098 datm_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
@@ -5202,7 +5202,7 @@ Test 098 datm_bulk_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_mx025_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_mx025_cfsr
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_mx025_cfsr
 Checking test 099 datm_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5214,7 +5214,7 @@ Test 099 datm_mx025_cfsr PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_mx025_gefs
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_mx025_gefs
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_mx025_gefs
 Checking test 100 datm_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -5226,7 +5226,7 @@ Test 100 datm_mx025_gefs PASS
 
 
 baseline dir = /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/RT/NEMSfv3gfs/develop-20210106/datm_debug_cfsr
-working dir  = /gpfs/dell2/ptmp/Dusan.Jovic/FV3_RT/rt_36675/datm_debug_cfsr
+working dir  = /gpfs/dell2/ptmp/Denise.Worthen/FV3_RT/rt_127401/datm_debug_cfsr
 Checking test 101 datm_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
@@ -5235,5 +5235,5 @@ Test 101 datm_debug_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan  6 21:48:35 UTC 2021
-Elapsed time: 02h:09m:23s. Have a nice day!
+Fri Jan  8 17:04:49 UTC 2021
+Elapsed time: 02h:48m:56s. Have a nice day!

--- a/tests/fv3_conf/ccpp_gfs_v16_run_c192L127.IN
+++ b/tests/fv3_conf/ccpp_gfs_v16_run_c192L127.IN
@@ -1,0 +1,23 @@
+rm -fr INPUT RESTART
+rsync -arv @[INPUTDATA_ROOT]/FV3_input_data_c192L127/INPUT/ INPUT/
+mkdir RESTART
+if [ $WARM_START = .T. ]; then
+  rsync -arv ../fv3_ccpp_gfs_v16_c192L127${RT_SUFFIX}/RESTART/ INPUT/
+  cd INPUT
+  rename 20190120.000000. '' 20190120.000000.*
+  cd ..
+fi
+
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/aerosol.dat .
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/co2historicaldata_201*.txt .
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/sfc_emissivity_idx.txt .
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/solarconstant_noaa_an.txt .
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/global_o3prdlos.f77 ./global_o3prdlos.f77
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/global_h2o_pltc.f77 ./global_h2oprdlos.f77
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/*grb .
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/*_table .
+cp    @[INPUTDATA_ROOT]/FV3_input_data_c192L127/*configure .
+
+if [ $DO_RRTMGP = .T. ]; then
+  cp @[INPUTDATA_ROOT]/FV3_input_data_c192L127/rrtmgp* .
+fi

--- a/tests/parm/ccpp_v16_c192L127_rrtmgp.nml.IN
+++ b/tests/parm/ccpp_v16_c192L127_rrtmgp.nml.IN
@@ -1,0 +1,337 @@
+﻿&amip_interp_nml
+  interp_oi_sst = .true.
+  use_ncep_sst = .true.
+  use_ncep_ice = .false.
+  no_anom_sst = .false.
+  data_set = 'reynolds_oi'
+  date_out_of_range = 'climo'
+/
+
+&atmos_model_nml
+  blocksize = 32
+  chksum_debug = .false.
+  dycore_only = .false.
+  fdiag = 1
+  fhmax = 384
+  fhout = 3
+  fhmaxhf = 120
+  fhouthf = 1
+  ccpp_suite = '@[CCPP_SUITE]'
+/
+
+&diag_manager_nml
+  prepend_date = .false.
+/
+
+&fms_io_nml
+  checksum_required = .false.
+  max_files_r = 100
+  max_files_w = 100
+/
+
+&mpp_io_nml
+shuffle=1
+deflate_level=1
+/
+
+&fms_nml
+  clock_grain = 'ROUTINE'
+  domains_stack_size = 3000000
+  print_memory_usage = .false.
+/
+
+&fv_core_nml
+  layout = 3,8
+  io_layout = 1,1
+  npx = @[NPX]
+  npy = @[NPY]
+  ntiles = 6
+  npz = @[NPZ]
+  grid_type = -1
+  make_nh = .true.
+  fv_debug = .false.
+  range_warn = .false.
+  reset_eta = .false.
+  n_sponge = 42
+  nudge_qv = .true.
+  nudge_dz = .false.
+  tau = 10.
+  rf_cutoff = 7.5e2
+  d2_bg_k1 = 0.20
+  d2_bg_k2 = 0.04
+  kord_tm = -9
+  kord_mt = 9
+  kord_wz = 9
+  kord_tr = 9
+  hydrostatic = .false.
+  phys_hydrostatic = .false.
+  use_hydro_pressure = .false.
+  beta = 0.
+  a_imp = 1.
+  p_fac = 0.1
+  k_split = 2
+  n_split = 6
+  nwat = 6
+  na_init = 1
+  d_ext = 0.
+  dnats = 1
+  fv_sg_adj = 450
+  d2_bg = 0.
+  nord = 2
+  dddmp = 0.1
+  d4_bg = 0.12
+  vtdm4 = 0.02
+  delt_max = 0.002
+  ke_bg = 0.
+  do_vort_damp = .true.
+  external_ic = .true.
+  external_eta = .true.
+  gfs_phil = .false.
+  nggps_ic = .true.
+  mountain = .false.
+  ncep_ic = .false.
+  d_con = 1.
+  hord_mt = 5
+  hord_vt = 5
+  hord_tm = 5
+  hord_dp = 5
+  hord_tr = 8
+  adjust_dry_mass = .false.
+  consv_te = 1.
+  do_sat_adj = .true.
+  consv_am = .false.
+  fill = .true.
+  dwind_2d = .false.
+  print_freq = 6
+  warm_start = .false.
+  no_dycore = .false.
+  z_tracer = .true.
+  agrid_vel_rst = .true.
+  read_increment = .false.
+  res_latlon_dynamics = ""
+/
+
+&external_ic_nml
+  filtered_terrain = .true.
+  levp = @[NPZP]
+  gfs_dwinds = .true.
+  checker_tr = .false.
+  nt_checker = 0
+/
+
+&gfs_physics_nml
+  fhzero       = 6
+  h2o_phys     = .true.
+  ldiag3d      = .false.
+  fhcyc        = 24
+  use_ufo      = .true.
+  pre_rad      = .false.
+  ncld         = 5
+  imp_physics  = 11
+  pdfcld       = .false.
+  fhswr        = 3600.
+  fhlwr        = 3600.
+  ialb         = 1
+  iems         = 1
+  iaer         = 5111
+  icliq_sw     = 2
+  iovr         = 3
+  ico2         = 2
+  isubc_sw     = 2
+  isubc_lw     = 2
+  isol         = 2
+  lwhtr        = .true.
+  swhtr        = .true.
+  cnvgwd       = .true.
+  shal_cnv     = .true.
+  cal_pre      = .false.
+  redrag       = .true.
+  dspheat      = .true.
+  hybedmf      = .false.
+  satmedmf     = .true.
+  isatmedmf    = 1
+  lheatstrg    = .false.
+  random_clds  = .false.
+  trans_trac   = .true.
+  cnvcld       = .true.
+  imfshalcnv   = 2
+  imfdeepcnv   = 2
+  cdmbgwd      = 0.23,1.5,1.0,1.0
+  prslrd0      = 0.
+  ivegsrc      = 1
+  isot         = 1
+  lsoil        = 4
+  lsm          = 1
+  iopt_dveg    = 1
+  iopt_crs     = 1
+  iopt_btr     = 1
+  iopt_run     = 1
+  iopt_sfc     = 1
+  iopt_frz     = 1
+  iopt_inf     = 1
+  iopt_rad     = 1
+  iopt_alb     = 2
+  iopt_snf     = 4
+  iopt_tbot    = 2
+  iopt_stc     = 1
+  debug        = .false.
+  oz_phys      = .F.
+  oz_phys_2015 = .T.
+  nstf_name    = 2,0,0,0,0
+  nst_anl      = .true.
+  psautco      = 0.0008,0.0005
+  prautco      = 0.00015,0.00015
+  lgfdlmprad   = .true.
+  effr_in      = .true.
+  ldiag_ugwp   = .false.
+  do_ugwp      = .false.
+  do_tofd      = .true.
+  do_sppt      = .false.
+  do_shum      = .false.
+  do_skeb      = .false.
+  lndp_type      = @[LNDP_TYPE]
+  n_var_lndp     = @[N_VAR_LNDP]
+  do_RRTMGP      = .true.
+  active_gases   = 'h2o_co2_o3_n2o_ch4_o2'
+  ngases         = 6
+  lw_file_gas    = 'rrtmgp-data-lw-g256-2018-12-04.nc'
+  lw_file_clouds = 'rrtmgp-cloud-optics-coeffs-lw.nc'
+  sw_file_gas    = 'rrtmgp-data-sw-g224-2018-12-04.nc'
+  sw_file_clouds = 'rrtmgp-cloud-optics-coeffs-sw.nc'
+  doG_cldoptics = .true.
+  rrtmgp_ngauss_ang = 3
+  rrtmgp_nrghice = 3
+  lsoil_lsm    = 4
+  do_mynnedmf  = .false.
+  do_mynnsfclay = .false.
+  icloud_bl    = 1
+  bl_mynn_edmf = 1
+  bl_mynn_tkeadvect = .false.
+  bl_mynn_edmf_mom = 1
+  min_lakeice  = 0.15
+  min_seaice   = 0.15
+
+/
+
+&gfdl_cloud_microphysics_nml
+  sedi_transport = .true.
+  do_sedi_heat = .false.
+  rad_snow = .true.
+  rad_graupel = .true.
+  rad_rain = .true.
+  const_vi = .F.
+  const_vs = .F.
+  const_vg = .F.
+  const_vr = .F.
+  vi_max = 1.
+  vs_max = 2.
+  vg_max = 12.
+  vr_max = 12.
+  qi_lim = 1.
+  prog_ccn = .false.
+  do_qa = .true.
+  fast_sat_adj = .true.
+  tau_l2v = 225.
+  tau_v2l = 150.
+  tau_g2v = 900.
+  rthresh = 10.e-6  ! This is a key parameter for cloud water
+  dw_land  = 0.16
+  dw_ocean = 0.10
+  ql_gen = 1.0e-3
+  ql_mlt = 1.0e-3
+  qi0_crt = 8.0E-5
+  qs0_crt = 1.0e-3
+  tau_i2s = 1000.
+  c_psaci = 0.05
+  c_pgacs = 0.01
+  rh_inc = 0.30
+  rh_inr = 0.30
+  rh_ins = 0.30
+  ccn_l = 300.
+  ccn_o = 100.
+  c_paut = 0.5
+  c_cracw = 0.8
+  use_ppm = .false.
+  use_ccn = .true.
+  mono_prof = .true.
+  z_slope_liq  = .true.
+  z_slope_ice  = .true.
+  de_ice = .false.
+  fix_negative = .true.
+  icloud_f = 1
+  mp_time = 150.
+  reiflag = 2
+/
+
+&interpolator_nml
+  interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+  FNGLAC   = 'global_glacier.2x2.grb'
+  FNMXIC   = 'global_maxice.2x2.grb'
+  FNTSFC   = 'RTGSST.1982.2012.monthly.clim.grb'
+  FNSNOC   = 'global_snoclim.1.875.grb'
+  FNZORC   = 'igbp'
+  FNALBC   = @[FNALBC]
+  FNALBC2  = 'global_albedo4.1x1.grb'
+  FNAISC   = 'CFSR.SEAICE.1982.2012.monthly.clim.grb'
+  FNTG3C   = 'global_tg3clim.2.6x1.5.grb'
+  FNVEGC   = 'global_vegfrac.0.144.decpercent.grb'
+  FNVETC   = @[FNVETC]
+  FNSOTC   = @[FNSOTC]
+  FNSMCC   = @[FNSMCC]
+  FNMSKH   = 'seaice_newland.grb'
+  FNTSFA   = ''
+  FNACNA   = ''
+  FNSNOA   = ''
+  FNVMNC   = 'global_shdmin.0.144x0.144.grb'
+  FNVMXC   = 'global_shdmax.0.144x0.144.grb'
+  FNSLPC   = 'global_slope.1x1.grb'
+  FNABSC   = @[FNABSC]
+  LDEBUG   = .false.
+  FSMCL(2) = 99999
+  FSMCL(3) = 99999
+  FSMCL(4) = 99999
+  LANDICE  = .true.
+  FTSFS    = 90
+  FAISL    = 99999
+  FAISS    = 99999
+  FSNOL    = 99999
+  FSNOS    = 99999
+  FSICL    = 99999
+  FSICS    = 99999
+  FTSFL    = 99999
+  FVETL    = 99999
+  FSOTL    = 99999
+  FvmnL    = 99999
+  FvmxL    = 99999
+  FSLPL    = 99999
+  FABSL    = 99999
+/
+
+&fv_grid_nml
+  grid_file = 'INPUT/grid_spec.nc'
+/
+
+&nam_stochy
+/
+
+&nam_sfcperts
+/
+
+&cires_ugwp_nml
+  knob_ugwp_solver  = 2
+  knob_ugwp_source  = 1,1,0,0
+  knob_ugwp_wvspec  = 1,25,25,25
+  knob_ugwp_azdir   = 2,4,4,4
+  knob_ugwp_stoch   = 0,0,0,0
+  knob_ugwp_effac   = 1,1,1,1
+  knob_ugwp_doaxyz  = 1
+  knob_ugwp_doheat  = 1
+  knob_ugwp_dokdis  = 1
+  knob_ugwp_ndx4lh  = 1
+  knob_ugwp_version = 0
+  launch_level      = 54
+/
+

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -83,6 +83,7 @@ RUN     | fv3_ccpp_gfs_v16beta_restart                                          
 RUN     | fv3_ccpp_gfs_v16beta_stochy                                                                                             |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP                                                                                               |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16beta_RRTMGP                                                                                             |                                         | fv3 |
+RUN     | fv3_ccpp_gfs_v16_RRTMGP_c192L127                                                                                        |                                         | fv3 |
 
 COMPILE | SUITES=FV3_GFS_v16_csawmg                                                                                               |                                         | fv3 |
 # fv3_ccpp_gfsv16_csawmg crashes with a "bus error" on cheyenne.intel, turn off both tests

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -103,7 +103,9 @@ RUN     | fv3_ccpp_esg_HAFS_v0_hwrf_thompson                                    
 ###################################################################################################################################################################################
 
 # Exercise compilation without specifying suites (i.e. compile all suites) in DEBUG mode (faster than in PROD mode)
-COMPILE | DEBUG=Y                                                                                                                 |                                         | fv3 |
+# Note: weird bug on Cheyenne, compiling without SUITES=... works fine on the login nodes, but crashes on the compute nodes; same issues on wcoss_cray and wcoss_dell_p3
+COMPILE | DEBUG=Y                                                                                                               | - cheyenne.intel wcoss_cray wcoss_dell_p3 | fv3 |
+COMPILE | DEBUG=Y SUITES='FV3_GFS_v15p2,FV3_GFS_v15p2_RRTMGP,FV3_GFS_v16beta,FV3_GFS_v16beta_RRTMGP'                            | + cheyenne.intel wcoss_cray wcoss_dell_p3 | fv3 |
 RUN     | fv3_ccpp_gfs_v15p2_debug                                                                                                |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v16beta_debug                                                                                              |                                         | fv3 |
 RUN     | fv3_ccpp_gfs_v15p2_RRTMGP_debug                                                                                         |                                         | fv3 |

--- a/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_c192L127
+++ b/tests/tests/fv3_ccpp_gfs_v16_RRTMGP_c192L127
@@ -1,0 +1,103 @@
+###############################################################################
+#
+#  FV3 CCPP GFS v16 w/ RRTMGP test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 c192L217 CCPP GFS v16 w/ RRTMGP results with previous trunk version"
+
+export CNTL_DIR=fv3_gfs_v16_RRTMGP_c192L127
+
+export LIST_FILES="phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc"
+
+
+export_fv3
+
+export DO_RRTMGP=.T.
+export TASKS=150
+export INPES=3
+export JNPES=8
+export NPX=193
+export NPY=193
+export NPZ=127
+export NPZP=128
+export SYEAR=2019
+export SMONTH=01
+export SDAY=20
+export DT_ATMOS=450
+export FHMAX=24
+export WLCLK=30
+export WRITE_GROUP=1
+export WRTTASK_PER_GROUP=6
+export OUTPUT_GRID="'cubed_sphere_grid'"
+export OUTPUT_FILE="'netcdf'"
+export WRITE_NEMSIOFLIP=.true.
+export WRITE_FSYNCFLAG=.true.
+export IMO=768
+export JMO=384
+export FNALBC="'global_snowfree_albedo.bosu.t382.768.384.rg.grb',"
+export FNVETC="'global_vegtype.igbp.t382.768.384.rg.grb',"
+export FNSOTC="'global_soiltype.statsgo.t382.768.384.rg.grb',"
+export FNSMCC="'global_soilmgldas.statsgo.t382.768.384.grb',"
+export FNABSC="'global_mxsnoalb.uariz.t382.768.384.rg.grb',"
+
+export FV3_RUN=ccpp_gfs_v16_run_c192L127.IN
+export CCPP_SUITE=FV3_GFS_v16beta_RRTMGP
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_v16_c192L127_rrtmgp.nml.IN
+


### PR DESCRIPTION
…_v16_rrtmgp suite file only

## Description

Add c192L27 GFSv16 rrtmgp test. It also includes CCPP [PR #546](https://github.com/NCAR/ccpp-physics/pull/546) to fix issues of compiling the fv3_GFS_v16beta_RRTMGP suite file only.

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes ccpp physics [#545](https://github.com/NCAR/ccpp-physics/issues/545)
- ufs-weather-model issue [#359](https://github.com/ufs-community/ufs-weather-model/issues/359)


## Testing

How were these changes tested?
What compilers / HPCs was it tested with?
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
