### PR TITLE
Update HPC stack on Cheyenne

### DIFF
--- a/modulefiles/ufs_cheyenne.gnu
+++ b/modulefiles/ufs_cheyenne.gnu
@@ -15,8 +15,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
-module load hpc/1.1.0
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack
+module load hpc/1.2.0
 module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22
 

--- a/modulefiles/ufs_cheyenne.gnu_debug
+++ b/modulefiles/ufs_cheyenne.gnu_debug
@@ -15,8 +15,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
-module load hpc/1.1.0
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack
+module load hpc/1.2.0
 module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22
 

--- a/modulefiles/ufs_cheyenne.intel
+++ b/modulefiles/ufs_cheyenne.intel
@@ -15,8 +15,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
-module load hpc/1.1.0
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack
+module load hpc/1.2.0
 module load hpc-intel/2021.2
 module load hpc-mpt/2.22
 

--- a/modulefiles/ufs_cheyenne.intel_debug
+++ b/modulefiles/ufs_cheyenne.intel_debug
@@ -15,8 +15,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
-module load hpc/1.1.0
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack
+module load hpc/1.2.0
 module load hpc-intel/2021.2
 module load hpc-mpt/2.22
 


### PR DESCRIPTION
@DeniseWorthen Please merge this into your ESMF update PR. The queue is long on Cheyenne today, but the tests that ran so far for GNU and Intel reproduced were b4b identical with the existing baselines.

Thanks!